### PR TITLE
fix: bandaid for Agent#request being undefined

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -18,6 +18,7 @@ import {
     getInfo,
     getOauthToken,
     getPlaylistInfo,
+    setAgent,
     setClientID,
     setOauthToken,
     streamFromInfoSync,
@@ -25,6 +26,7 @@ import {
     validatePlaylistURL,
     validateURL
 } from "scdl-core";
+import { Agent } from "undici";
 import { fileURLToPath } from "url";
 import { readConfig, writeConfig } from "./config.js";
 import parseArgs from "./parseArgs.js";
@@ -56,6 +58,7 @@ try {
         hadAction = true;
         if (playlist ? validatePlaylistURL(query) : validateURL(query)) {
             let options;
+            setAgent(new Agent());
             if (!getClientID() && !getOauthToken()) {
                 const configOauthToken = readConfig();
                 if (configOauthToken) {


### PR DESCRIPTION
Strange issue that I don't have the motivation to fix at the moment

Describing here for myself to look at later:
```js
import "scdl-core";
import { getGlobalDispatcher } from "undici";

getGlobalDispatcher().request();
```
- This errors with `TypeError: getGlobalDispatcher(...).request is not a function` on Node.js v22.13.0 due to `Agent#request` being `undefined`.
- The object returned by `getGlobalDispatcher` *is* still an `Agent`, and `Agent#dispatch` *is* still present and could be used for a different workaround.
- It does *not* error within tests for `scdl-core`
- It does *not* error when using CommonJS
- It does *not* error on Node.js v20.17.0 or v24.8.0
- I had previously remembered it working as expected on undici v5 and v6, but currently the issue is only resolved by rolling back to undici v4

For the curious, the *only* time I access undici (outside of type-only imports) is when importing `getGlobalDispatcher`. At no point do I override or extend anything related to undici as a whole.